### PR TITLE
fixed non existant file cache removal

### DIFF
--- a/Directory.java
+++ b/Directory.java
@@ -96,7 +96,7 @@ public class Directory {
             if (!archive.getFile().exists())
                 archiveDeletions.add(archive);
 
-            if (!String.valueOf(archive.getFile().lastModified()).equals(archive.getLastModified())) {
+            else if (!String.valueOf(archive.getFile().lastModified()).equals(archive.getLastModified())) {
                 archiveDeletions.add(archive);
                 archiveAditions.add(archive);
             }


### PR DESCRIPTION
If a deleted file was cached, it wasn't properly removed and caused FileNotFoundException